### PR TITLE
fix: evaluation service tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,4 @@ module.exports = {
   },
   testEnvironment: 'node',
   setupFilesAfterEnv: ['./test/setup.js'],
-  moduleNameMapper: {
-    '^node-fetch$': "<rootDir>/mocks/node-fetch.js"
-  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "muggle2mage",
       "version": "0.0.0",
       "dependencies": {
-        "node-fetch": "^3.3.2",
+        "node-fetch": "^2.7.0",
         "toml": "^3.0.0"
       },
       "devDependencies": {
@@ -3728,28 +3728,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/fetch-mock": {
       "version": "9.11.0",
       "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
@@ -3836,17 +3814,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -5144,47 +5111,42 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
+        "whatwg-url": "^5.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "4.x || >=6.0.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
-    "node_modules/node-fetch/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "engines": {
-        "node": ">= 12"
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -6086,14 +6048,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "private": true,
   "dependencies": {
-    "node-fetch": "^3.3.2",
+    "node-fetch": "^2.7.0",
     "toml": "^3.0.0"
   }
 }

--- a/test/EvaluationService.test.js
+++ b/test/EvaluationService.test.js
@@ -11,32 +11,37 @@ describe('evaluateAnswer in EvaluationService', () => {
   it('returns the evaluated text on a successful API call', async () => {
     // Mock the OpenAI API response
     const mockResponse = {
-      choices: [{
-        text: "This is a test evaluation."
-      }]
+      choices: [
+        {
+          text: "This is a test evaluation.",
+        },
+      ],
     };
-  
+
     // Use global.fetch mock to simulate the API response
-    global.fetch.mock(JSON.stringify(mockResponse), { status: 200 });
-  
+    global.fetch.mock(
+      'https://api.openai.com/v1/engines/davinci/completions',
+      JSON.stringify(mockResponse)
+    );
+
     const userMessage = "Test message";
     const result = await evaluateAnswer(userMessage);
-       
-    expect(global.fetch).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/engines/davinci/completions',
+      {
         method: "POST",
         headers: {
-          'Content-Type': 'application/json',
-          "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
         },
-        // This line checks that the body, when parsed back into an object, has a property that contains the userMessage
-        body: expect.stringContaining(JSON.stringify(expect.objectContaining({
-          prompt: userMessage
-        })))
-      }));
-  
+        body: '{"prompt":"The user\'s answer is: \\"Test message\\". Evaluate the correctness and provide feedback.","max_tokens":150,"temperature":0.5,"top_p":1,"frequency_penalty":0,"presence_penalty":0,"stop":["\\n"]}',
+      }
+    );
+
     expect(result).toEqual("This is a test evaluation.");
   });
-  
+
 
   it('returns an error message on a failed API call', async () => {
     // Mock a failed API response


### PR DESCRIPTION
Changes:
- **jest.config.js**: Removed buggy code (it was mocking node-fetch to every call, which conflicts with fetch-mock-jest (it needs the real module to work well)
- **package.json**: The node-fetch version 3x works with ESM, with breaks if you are not using transpiler, so it's downgraded to 2x version
- [test/EvaluationService.test.js](https://github.com/ggoveia/muggle2mage/compare/master...fix/evaluation_tests?expand=1#diff-0f581079716533ba5751c8d65c16a454fa2c3410e7bad3d430634575656fa098) : fixed tests and assertions
